### PR TITLE
FIX wrong redirect to root_url to '/orchestrator/'

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1483,7 +1483,7 @@ class Airflow(BaseView):
 
         dagbag.get_dag(dag_id)
         flash("DAG [{}] is now fresh as a daisy".format(dag_id))
-        return redirect('/')
+        return redirect('/orchestrator/')
 
     @expose('/refresh_all')
     @login_required
@@ -1491,7 +1491,7 @@ class Airflow(BaseView):
     def refresh_all(self):
         dagbag.collect_dags(only_if_updated=False)
         flash("All DAGs are now up to date")
-        return redirect('/')
+        return redirect('/orchestrator/')
 
     @expose('/gantt')
     @login_required


### PR DESCRIPTION
This PR fixes some routes that are redirecting to the upstream_server declared in nginx/kong.

@thoralf-gutierrez can you check why the builds are failing? There are still some routes redirecting to `/`, when they should actually redirect to `/orchestrator/`.
