### PR TITLE
Fix the computation of root nodes to also work with self-loops

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2355,7 +2355,7 @@ class DAG(LoggingMixin):
 
     @property
     def roots(self):
-        return [t for t in self.tasks if not t.downstream_list]
+        return [t for t in self.tasks if not [downstream for downstream in t.downstream_list if not downstream == t]]
 
     @provide_session
     def set_dag_runs_state(


### PR DESCRIPTION
In our version of airflow we allow self-loops (as long as they are not on the same day).
The existing computation of the `roots` of the dag does not support this use case: A root with a self loop is not actually considered a root. (In a sense, self loops are not even allowed in a DAG. In fact I think there might be some more gotchas that we should talk about at some point.)

The "flattening" of the dag that we saw is explained by the fact that the UI rendering of the dag starts adding edges from the roots. When the roots are not recognised as such we're not adding any edges.
In the tree view we only saw the nodes attached to a root without a self loop which happened to be the orphaned nodes.

The reason that the dag that previously worked did not seem to work any more is that a self loop was added to a previously correctly recognised root node here: https://github.com/RealImpactAnalytics/datamodule-snd-coverage-app/pull/23/files#diff-17f831464eaaf5fbb93be0fb0e75f429R39
This triggered the bug.

The reason why https://github.com/RealImpactAnalytics/orchestrator/pull/20 at first seemed to resolve the issue is that `add_trigger` does not add anything to the `downstream_list` and accordingly every node is treated as a root. The display hence worked correctly (but probably this would have broken something else).

@thoralf-gutierrez, @pierre-borckmans could you please review?
