### PR TITLE
Fix problem that upstream_failed tasks are not registered as such

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -829,12 +829,18 @@ class TaskInstance(Base):
 
             if tt == TriggerType.ALL and any(skipped):
                 self.set_state(State.SKIPPED, session)
+                logging.error("Recording the task instance as SKIPPED because an upstream task was skipped")
+                session.commit()
 
             elif tt == TriggerType.ALL and any(failed):
                 self.set_state(State.UPSTREAM_FAILED, session)
+                logging.error("Recording the task instance as UPSTREAM_FAILED because an upstream task has failed")
+                session.commit()
 
             elif tt == TriggerType.ANY and all(done) and not any(triggered):
                 self.set_state(State.SKIPPED, session)
+                logging.error("Recording the task instance as SKIPPED")
+                session.commit()
 
         if self.task.trigger_type == TriggerType.ALL and all(triggered):
             return True


### PR DESCRIPTION
In the orchestrator we're seeing the problem that a a failed upstream task does not correctly mark the downstream tasks as failed which causes the dag run to never terminate and hence we don't proceed to the next day if there's any task with a failure in any of its dependencies.

The problem is that we set the state on the task instance but previously did not commit the session to write this information out into the database. The task instance object itself is ephemeral and the information about upstream failures hence gets lost. This can be fixed by explicitly committing the session.

In my local tests I now get the following image:

<img width="585" alt="screen shot 2016-04-15 at 11 59 44" src="https://cloud.githubusercontent.com/assets/1372814/14558257/9fc8abbe-0301-11e6-9175-a19cfb9b2ee7.png">
<img width="871" alt="screen shot 2016-04-15 at 11 51 30" src="https://cloud.githubusercontent.com/assets/1372814/14558258/9fc9f956-0301-11e6-8f73-b8aea5a85b14.png">

There are a few UI-tweaks we could still do:
- The orange for `upstream_failure` is hard to see in the graph view
- The information orange = `upstream_failure` is missing in the legend of both graph and tree view

I suggest, however, that these tweaks should be part of a separate PR.

@thoralf-gutierrez, @pierre-borckmans I'd appreciate your feedback :wink: 
